### PR TITLE
fix(ci): use PR author instead of actor for auto-merge check

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -14,7 +14,9 @@ jobs:
   auto-merge:
     name: Auto-merge dependency PRs
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+    # Use PR author login instead of github.actor to handle synchronize events
+    # when someone else pushes to the dependabot/renovate branch
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
 
     steps:
       - name: Harden Runner
@@ -24,7 +26,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        if: github.actor == 'dependabot[bot]'
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
         uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Fix auto-merge workflow skipping dependabot/renovate PRs after someone else pushes to the branch
- Change condition from `github.actor` to `github.event.pull_request.user.login`

## Problem
The workflow was using `github.actor` which reflects **who triggered the event**, not the PR author:
- `opened` event → `github.actor = dependabot[bot]`
- `synchronize` event (after someone pushes) → `github.actor = <that user>`

This caused PR #14 to skip auto-merge.

## Solution
Use `github.event.pull_request.user.login` which always reflects the original PR author.

## Test plan
- [ ] Verify existing dependabot PRs will be processed by re-triggering the workflow